### PR TITLE
output is now 100% ASCII

### DIFF
--- a/analyze_hccapx.pl
+++ b/analyze_hccapx.pl
@@ -174,7 +174,7 @@ while (read (HCCAPX_FILE, $struct_content, $HCCAPX_STRUCT_SIZE))
   print "HCCAPX {\n";
   print "  version:      " . unpack ("L*", $version) . "\n";
   print "  message_pair: " . unpack ("C*", $message_pair) . " (" . $message_pair_info . ")\n";
-  print "  essid:        " . $essid . "\n";
+  print "  essid:        " . unpack ("A*", $essid) . "\n";
   print "  keyver:       "   . unpack ("C*", $keyver) . " (" . $keyver_info . ")\n";
   print "  keymic:       "   . unpack ("H*", $keymic) . "\n";
   print "  MACS:\n";


### PR DESCRIPTION
the ESSID was not converted to ASCII thus giving an output that was uneasy to work with, with standard tools. This fixes that.